### PR TITLE
Fix version file URL and KSP_VERSION_MIN

### DIFF
--- a/GameData/KerbalOccupationColors/KerbalOccupationColors.version
+++ b/GameData/KerbalOccupationColors/KerbalOccupationColors.version
@@ -8,6 +8,12 @@
 		"PATCH": 0,
 		"BUILD": 2
 	},
+	"KSP_VERSION":
+	{
+		"MAJOR": 1,
+		"MINOR": 8,
+		"PATCH": 0
+	},
 	"KSP_VERSION_MIN":
 	{
 		"MAJOR": 1,

--- a/GameData/KerbalOccupationColors/KerbalOccupationColors.version
+++ b/GameData/KerbalOccupationColors/KerbalOccupationColors.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "KerbalOccupationColors",
-	"URL": "https://raw.githubusercontent.com/Starwaster/Kerbal-Occupation-Colors/master/KerbalOccupationColors.version",
+	"URL": "https://github.com/Starwaster/Kerbal-Occupation-Colors/raw/master/GameData/KerbalOccupationColors/KerbalOccupationColors.version",
 	"VERSION":
 	{
 		"MAJOR": 1,
@@ -8,16 +8,10 @@
 		"PATCH": 0,
 		"BUILD": 2
 	},
-	"KSP_VERSION":
+	"KSP_VERSION_MIN":
 	{
 		"MAJOR": 1,
 		"MINOR": 8,
 		"PATCH": 0
-	},
-	"KSP_VERSION_MIN":
-	{
-		"MAJOR": 1,
-		"MINOR": 99999,
-		"PATCH": 99999
-	}	
+	}
 }


### PR DESCRIPTION
The version file has two problems:

- The `URL` property contained a link to a non-existent file, which means KSP-AVC won't be able to check for updates
- The `KSP_VERSION_MIN` property was set to 1.99999.99999, which means this mod would only be considered compatible if the user had installed that version of KSP or later. There will probably never be such a version of KSP, so it's not compatible with anything. (This has blocked v1.2.0.1 from being indexed in CKAN.)

This PR fixes these issues.

- `URL` is set to the raw GitHub URL for this file
- `KSP_VERSION_MIN` is set to 1.8.0, to allow this mod to be considered compatible with that version of KSP and later

Note that a new release would be needed to make these fixes available to users.